### PR TITLE
Refactor Pagination and Moved pagination to a module

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,21 +1,16 @@
+require_relative "../../lib/middleware/standardJsonResponse"
+include ResponseStandardMiddleware
+
 class MoviesController < ApplicationController
-  before_action :pagination_params, only: %i[ index ]
+
+  before_action :pagination_params, only: %i[index]
 
   def index
-    @movies = Movie
-      .all
-      .page(params[:page] ? params[:page] : 1)
-      .per(params[:size] ? params[:size] : 20)
+    page, size = ResponseStandardMiddleware::ControllerPagination.buildPaginationParams(params)
 
-    render json: {
-      paginated: true,
-      movies: @movies,
-      next_page: @movies.next_page,
-      prev_page: @movies.prev_page,
-      last_page: @movies.last_page?,
-      per_page: @movies.limit_value,
-      total_pages: @movies.total_pages
-    }
+    @movies = Movie.all.page(page).per(size)
+
+    render json: ResponseStandardMiddleware::ControllerPagination.buildPaginatedResponse(@movies)
   end
 
   def recommendations
@@ -39,8 +34,7 @@ class MoviesController < ApplicationController
   end
 
   private
-
     def pagination_params
-      params.permit(:page, :size,)
+      params.permit(:page, :size)
     end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,6 @@ module CodespacesTryRails
     config.load_defaults 7.0
     config.api_only = true
 
-    config.middleware.use Middleware::StandardJsonResponse
+    config.middleware.use ResponseStandardMiddleware::StandardJsonResponse
   end
 end


### PR DESCRIPTION
Finish version of pagination. All routes with pagination can receive two params: `size`, how elements to return per page, and `page`, the page to return. Both have default values: page has 1 and size has 20.

Each route which returns the pagination, will follow the interface:

```
{
  data: data returned from controller,
  page: {
    total: total elements in the page,
    next_page: next page number or null,
    prev_page: previus page number or null,
    last_page: boolean,
    per_page: number of elements per page,
    total_pages: total number of pages
  }
}
```
